### PR TITLE
fix: Add runtime namespace/auth for generating TR APIs

### DIFF
--- a/.github/workflows/deploy-api.yml
+++ b/.github/workflows/deploy-api.yml
@@ -38,6 +38,9 @@ jobs:
           os: ${{ matrix.os }}
           version: 10.x.x
       - name: Generate Template Registry APIs
+        env:
+          AIO_runtime_auth: ${{ secrets.AIO_RUNTIME_AUTH }}
+          AIO_runtime_namespace: ${{ secrets.AIO_RUNTIME_NAMESPACE }}
         run: aio runtime api create --config-file=template-registry-api.json
       - name: Deploy
         env:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
The deploy.yaml github workflow is failing on Stage deployment on step "Generate Template Registry APIs". `error: ›   Error: failed to create the api: An AUTH key must be specified`
To fix this, added env variable runtime namespace and auth in this step.
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
