### PR TITLE
fix: do not allow null name or links params

### DIFF
--- a/actions/templates/post/index.js
+++ b/actions/templates/post/index.js
@@ -86,8 +86,8 @@ async function main (params) {
       ...(params.version && { version: params.version }), // developer console only
       ...(params.createdBy && { createdBy: params.createdBy }),
       links: {
-        ...(params.links.consoleProject && { consoleProject: params.links.consoleProject }), // developer console only
-        ...(params.links.github && { github: params.links.github }) // app builder only
+        ...(params?.links?.consoleProject && { consoleProject: params.links.consoleProject }), // developer console only
+        ...(params?.links?.github && { github: params.links.github }) // app builder only
       }
     };
 

--- a/template-registry-api.json
+++ b/template-registry-api.json
@@ -47,7 +47,8 @@
                     "name": {
                       "type": "string",
                       "description": "The name of the package implementing the template on npmjs.com",
-                      "example": "@adobe/app-builder-template"
+                      "example": "@adobe/app-builder-template",
+                      "nullable": false
                     },
                     "description": {
                       "type": "string",
@@ -68,6 +69,8 @@
                       "type": "object",
                       "description": "A link to the Github repository containing the package's source code",
                       "additionalProperties": false,
+                      "minProperties": 1,
+                      "nullable": false,
                       "properties": {
                         "github": {
                           "$ref": "#/components/schemas/GithubUrl"
@@ -938,6 +941,7 @@
         "GithubUrl": {
           "type": "string",
           "format": "uri",
+          "nullable": false,
           "pattern": "^https://github\\.com/",
           "description": "A link to the Github repository containing the package's source code",
           "example": "https://github.com/adobe/app-builder-template"
@@ -945,6 +949,7 @@
         "DeveloperConsoleUrl": {
           "type": "string",
           "format": "uri",
+          "nullable": false,
           "pattern": "^https://developer-stage\\.adobe\\.com/console/projects",
           "description": "A link to the console project",
           "example": "https://developer-stage.adobe.com/console/projects/<project-id>"

--- a/test/templates.post.test.js
+++ b/test/templates.post.test.js
@@ -495,4 +495,130 @@ describe('POST templates', () => {
     // expect(createReviewIssue).toHaveBeenCalledWith(TEMPLATE_NAME, TEMPLATE_GITHUB_REPO, process.env.ACCESS_TOKEN_GITHUB, process.env.TEMPLATE_REGISTRY_ORG, process.env.TEMPLATE_REGISTRY_REPOSITORY);
     expect(mockLoggerInstance.info).toHaveBeenCalledWith('"POST templates" executed successfully');
   });
+
+  test('Do not allow null name param', async () => {
+    const response = await action.main({
+      IMS_URL: process.env.IMS_URL,
+      IMS_CLIENT_ID: process.env.IMS_URL,
+      __ow_method: HTTP_METHOD,
+      name: null,
+      links: {
+        consoleProject: 'https://developer-stage.adobe.com/console/projects/1234'
+      },
+      ...fakeParams
+    });
+    expect(response).toEqual({
+      error: {
+        statusCode: 400,
+        body: {
+          errors: [
+            {
+              code: utils.ERR_RC_INCORRECT_REQUEST,
+              message: 'Request has one or more errors => In body => For Content-Type application/json => Unable to deserialize value => at: name => Expected a string. Received: null'
+            }
+          ]
+        }
+      }
+    });
+  });
+
+  test('Do not allow null links param', async () => {
+    const response = await action.main({
+      IMS_URL: process.env.IMS_URL,
+      IMS_CLIENT_ID: process.env.IMS_URL,
+      __ow_method: HTTP_METHOD,
+      name: 'test-project',
+      links: null,
+      ...fakeParams
+    });
+    expect(response).toEqual({
+      error: {
+        statusCode: 400,
+        body: {
+          errors: [
+            {
+              code: utils.ERR_RC_INCORRECT_REQUEST,
+              message: 'Request has one or more errors => In body => For Content-Type application/json => Invalid value => at: links => Expected object property count to be greater than or equal to undefined. Received: undefined'
+            }
+          ]
+        }
+      }
+    });
+  });
+
+  test('Do not allow null links.consoleProject param', async () => {
+    const response = await action.main({
+      IMS_URL: process.env.IMS_URL,
+      IMS_CLIENT_ID: process.env.IMS_URL,
+      __ow_method: HTTP_METHOD,
+      name: 'test-project',
+      links: {
+        consoleProject: null
+      },
+      ...fakeParams
+    });
+    expect(response).toEqual({
+      error: {
+        statusCode: 400,
+        body: {
+          errors: [
+            {
+              code: utils.ERR_RC_INCORRECT_REQUEST,
+              message: 'Request has one or more errors => In body => For Content-Type application/json => Invalid value => at: links => Expected object property count to be greater than or equal to undefined. Received: undefined'
+            }
+          ]
+        }
+      }
+    });
+  });
+
+  test('Do not allow null links.githubUrl param', async () => {
+    const response = await action.main({
+      IMS_URL: process.env.IMS_URL,
+      IMS_CLIENT_ID: process.env.IMS_URL,
+      __ow_method: HTTP_METHOD,
+      name: 'test-project',
+      links: {
+        githubUrl: null
+      },
+      ...fakeParams
+    });
+    expect(response).toEqual({
+      error: {
+        statusCode: 400,
+        body: {
+          errors: [
+            {
+              code: utils.ERR_RC_INCORRECT_REQUEST,
+              message: 'Request has one or more errors => In body => For Content-Type application/json => Invalid value => at: links => Expected object property count to be greater than or equal to undefined. Received: undefined'
+            }
+          ]
+        }
+      }
+    });
+  });
+
+  test('Do not allow both null name and links params', async () => {
+    const response = await action.main({
+      IMS_URL: process.env.IMS_URL,
+      IMS_CLIENT_ID: process.env.IMS_URL,
+      __ow_method: HTTP_METHOD,
+      name: null,
+      links: null,
+      ...fakeParams
+    });
+    expect(response).toEqual({
+      error: {
+        statusCode: 400,
+        body: {
+          errors: [
+            {
+              code: utils.ERR_RC_INCORRECT_REQUEST,
+              message: 'Request has one or more errors => In body => For Content-Type application/json => Unable to deserialize value => at: name => Expected a string. Received: null'
+            }
+          ]
+        }
+      }
+    });
+  });
 });


### PR DESCRIPTION
## Description

Testing with the Developer Console team, they were seeing server errors when sending `name: null` or `links: null` in the request body for creating a template. These should not be server errors, they should return as 400 Bad Request errors

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

`npm run test`, deployed changes to dev namespace

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
