### PR TITLE
fix: rename version to latestVersion

### DIFF
--- a/actions/templates/post/index.js
+++ b/actions/templates/post/index.js
@@ -83,7 +83,7 @@ async function main (params) {
     let body = {
       name: params.name,
       ...(params.description && { description: params.description }), // developer console only
-      ...(params.version && { version: params.version }), // developer console only
+      ...(params.latestVersion && { latestVersion: params.latestVersion }), // developer console only
       ...(params.createdBy && { createdBy: params.createdBy }),
       links: {
         ...(params?.links?.consoleProject && { consoleProject: params.links.consoleProject }), // developer console only

--- a/template-registry-api.json
+++ b/template-registry-api.json
@@ -60,7 +60,7 @@
                       "description": "The name of the user who created the template",
                       "example": "Lazarus"
                     },
-                    "version": {
+                    "latestVersion": {
                       "type": "string",
                       "description": "The version of the template in the semver format",
                       "example": "1.0.0"
@@ -782,11 +782,6 @@
               "type": "string",
               "description": "The name of the user who created the template",
               "example": "Lazarus"
-            },
-            "version": {
-              "type": "string",
-              "description": "The version of the template in the semver format",
-              "example": "1.0.0"
             },
             "description": {
               "type": "string",

--- a/test/templates.post.test.js
+++ b/test/templates.post.test.js
@@ -347,7 +347,7 @@ describe('POST templates', () => {
       name: templateName,
       description: 'Developer Console template',
       status: 'InVerification',
-      version: '1.0.0',
+      latestVersion: '1.0.0',
       links: {
         consoleProject: DEVELOPER_CONSOLE_PROJECT
       }
@@ -369,7 +369,7 @@ describe('POST templates', () => {
         consoleProject: DEVELOPER_CONSOLE_PROJECT
       },
       description: 'Developer Console template',
-      version: '1.0.0',
+      latestVersion: '1.0.0',
       createdBy: 'Capernicus',
       ...fakeParams
     });
@@ -408,7 +408,7 @@ describe('POST templates', () => {
         consoleProject: DEVELOPER_CONSOLE_PROJECT
       },
       description: 'Developer Console template',
-      version: '1.0.0',
+      latestVersion: '1.0.0',
       createdBy: 'Capernicus'
     });
     // TODO: Uncomment the following after integrating with App Builder templates again
@@ -436,7 +436,7 @@ describe('POST templates', () => {
       name: templateName,
       description: 'Developer Console template',
       status: 'InVerification',
-      version: '1.0.0',
+      latestVersion: '1.0.0',
       links: {
         consoleProject: DEVELOPER_CONSOLE_PROJECT
       }
@@ -458,7 +458,7 @@ describe('POST templates', () => {
         consoleProject: DEVELOPER_CONSOLE_PROJECT
       },
       description: 'Developer Console template',
-      version: '1.0.0',
+      latestVersion: '1.0.0',
       ...fakeParams
     });
     expect(response).toEqual({
@@ -489,7 +489,7 @@ describe('POST templates', () => {
         consoleProject: DEVELOPER_CONSOLE_PROJECT
       },
       description: 'Developer Console template',
-      version: '1.0.0'
+      latestVersion: '1.0.0'
     });
     // TODO: Uncomment the following after integrating with App Builder templates again
     // expect(createReviewIssue).toHaveBeenCalledWith(TEMPLATE_NAME, TEMPLATE_GITHUB_REPO, process.env.ACCESS_TOKEN_GITHUB, process.env.TEMPLATE_REGISTRY_ORG, process.env.TEMPLATE_REGISTRY_REPOSITORY);


### PR DESCRIPTION
## Description

Technically this was a bug as `latestVersion` is what App Builder templates were using previously

## Related Issue

## Motivation and Context

## How Has This Been Tested?

`npm run test`, locally deployed changes

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
