### PR TITLE
fix: dont log sensitive param values

### DIFF
--- a/actions/utils.js
+++ b/actions/utils.js
@@ -21,18 +21,29 @@ const ERR_RC_PERMISSION_DENIED = 'permission_denied';
 /**
  *
  * Returns a log ready string of the action input parameters.
- * The `Authorization` header content will be replaced by '<hidden>'.
+ * Any sensitive content will be replaced by '<hidden>'.
  *
  * @param {object} params action input parameters.
  * @returns {string} a stringified version of the input parameters.
  */
 function stringParameters (params) {
+  const newParams = {
+    ...params,
+    ...(params.IMS_AUTH_CODE && { IMS_AUTH_CODE: '<hidden>' }),
+    ...(params.IMS_CLIENT_SECRET && { IMS_CLIENT_SECRET: '<hidden>' }),
+    ...(params.GITHUB_ACCESS_TOKEN && { GITHUB_ACCESS_TOKEN: '<hidden>' }),
+    ...(params.MONGODB_URI && { MONGODB_URI: '<hidden>' })
+  };
+
   // hide authorization token without overriding params
   let headers = params.__ow_headers || {};
   if (headers.authorization) {
-    headers = { ...headers, authorization: '<hidden>' };
+    headers = {
+      ...headers,
+      authorization: '<hidden>'
+    };
   }
-  return JSON.stringify({ ...params, __ow_headers: headers });
+  return JSON.stringify({ ...newParams, __ow_headers: headers });
 }
 
 /**

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -67,6 +67,29 @@ describe('stringParameters', () => {
     expect(utils.stringParameters(params)).toEqual(expect.stringContaining('"authorization":"<hidden>"'));
     expect(utils.stringParameters(params)).not.toEqual(expect.stringContaining('secret'));
   });
+  test('with sensitive values in params', () => {
+    const params = {
+      IMS_AUTH_CODE: '1234',
+      MONGODB_URI: 'mongodb://mongo:27017',
+      GITHUB_ACCESS_TOKEN: 'fake-token',
+      IMS_CLIENT_SECRET: 'secret'
+    };
+    expect(utils.stringParameters(params)).toEqual(expect.stringContaining(
+      '"IMS_AUTH_CODE":"<hidden>","MONGODB_URI":"<hidden>","GITHUB_ACCESS_TOKEN":"<hidden>","IMS_CLIENT_SECRET":"<hidden>"'
+    ));
+  });
+  test('with only some sensitive values in params', () => {
+    const params = {
+      IMS_AUTH_CODE: '1234',
+      MONGODB_URI: 'mongodb://mongo:27017',
+      GITHUB_ACCESS_TOKEN: 'fake-token'
+    };
+    const stringParams = utils.stringParameters(params);
+    expect(stringParams).toEqual(expect.stringContaining(
+      '"IMS_AUTH_CODE":"<hidden>","MONGODB_URI":"<hidden>","GITHUB_ACCESS_TOKEN":"<hidden>"'
+    ));
+    expect(stringParams).toEqual(expect.not.stringContaining('IMS_CLIENT_SECRET'));
+  });
 });
 
 describe('checkMissingRequestInputs', () => {


### PR DESCRIPTION
## Description

We should avoid logging any sensitive values, codes, or tokens to the service logs. We already hide the user's token, but this PR will make it so we also hide sensitive environment variables.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
