### PR TITLE
fix: stage deploy

### DIFF
--- a/.github/workflows/deploy-api.yml
+++ b/.github/workflows/deploy-api.yml
@@ -41,6 +41,7 @@ jobs:
         env:
           AIO_runtime_auth: ${{ secrets.AIO_RUNTIME_AUTH }}
           AIO_runtime_namespace: ${{ secrets.AIO_RUNTIME_NAMESPACE }}
+          AIO_runtime_apihost: ${{ secrets.AIO_RUNTIME_APIHOST }}
         run: aio runtime api create --config-file=template-registry-api.json
       - name: Deploy
         env:

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ governing permissions and limitations under the License.
 
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0) 
 
+
 # Template Registry API
 
 ## OpenAPI Schema


### PR DESCRIPTION
## Description

Build failure: https://github.com/adobe/adp-template-registry-api/actions/runs/8708672109/job/23886596444#step:6:8

This build failed because we updated the GitHub secrets to deploy to a new stage namespace that's actually in Runtime stage. The build above tried to create APIs in Runtime prod, but failed because the new stage namespace/auth only exists in Runtime stage. 

This PR adds the `AIO_RUNTIME_APIHOST` environment variable to the deploy api step so we can correctly target Runtime stage. 

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
