### PR TITLE
feat: Add support for license configs for APIs - Install template endpoint

### DIFF
--- a/actions/templates/install/index.js
+++ b/actions/templates/install/index.js
@@ -182,9 +182,12 @@ async function main (params) {
           continue;
         }
         // extract api license config from the api info map
+        // Note: adobeid type credentials do not support license configs because they do not have a technical account.
+        // TR Install API doesn't need to know this distinction between credential types and console will simply ignore in case license configs are included.
+
         let apiLicenseConfigs = [];
         const apiInfo = mapApiCodeToApiInfo[api.code];
-        if (apiInfo && apiInfo.credentialType.toLowerCase() === apiCredentialType.toLowerCase() && apiInfo.flowType.toLowerCase() === apiFlowType.toLowerCase()) {
+        if (apiInfo?.credentialType?.toLowerCase() === apiCredentialType.toLowerCase() && apiInfo?.flowType?.toLowerCase() === apiFlowType.toLowerCase()) {
           apiLicenseConfigs = apiInfo.licenseConfigs;
         }
         const service = {
@@ -220,7 +223,7 @@ async function main (params) {
         // extract api license config from the api info map
         let apiLicenseConfigs = [];
         const apiInfo = mapApiCodeToApiInfo[api.code];
-        if (apiInfo && apiInfo.credentialType.toLowerCase() === apiCredentialType.toLowerCase() && apiInfo.flowType.toLowerCase() === apiFlowType.toLowerCase()) {
+        if (apiInfo?.credentialType?.toLowerCase() === apiCredentialType.toLowerCase() && apiInfo?.flowType?.toLowerCase() === apiFlowType.toLowerCase()) {
           apiLicenseConfigs = apiInfo.licenseConfigs;
         }
 

--- a/template-registry-api.json
+++ b/template-registry-api.json
@@ -1159,6 +1159,33 @@
           "type": "object",
           "description": "Key value pairs of credential metadata like allowed domains, redirect uris etc",
           "additionalProperties": {}
+        },
+        "apis": {
+          "type": "array",
+          "description": "Optional field to include license configs to be assigned to a technical account for an individual API",
+            "items": {
+                "type": "object",
+                "properties": {
+                  "code": {
+                      "type": "string",
+                      "description": "API code"
+                  },
+                  "credentialType": {
+                      "type": "string",
+                      "description": "Credential type"
+                  },
+                  "FlowType": {
+                      "type": "string",
+                      "description": "Flow type"
+                  },
+                  "licenseConfigs": {
+                      "type": "array",
+                      "items": {
+                          "type": "object"
+                      }
+                  }
+                }
+            }
         }
       }
     },

--- a/test/templates.install.test.js
+++ b/test/templates.install.test.js
@@ -54,6 +54,7 @@ const mockParams = {
   projectName: 'mockProjectName',
   description: 'mockDescription',
   metadata: { mockMetadata: 'value' },
+
   __ow_headers: {
     authorization: `Bearer ${IMS_ACCESS_TOKEN}`
   }
@@ -975,6 +976,239 @@ describe('POST Install template: Core business logic specific tests', () => {
     expect(mockConsoleSDKInstance.createAdobeIdIntegration).toHaveBeenCalled();
     expect(mockConsoleSDKInstance.createOauthS2SCredentialIntegration).not.toHaveBeenCalled();
     expect(mockConsoleSDKInstance.createAdobeIdIntegration).toHaveBeenCalledWith('mockOrgId', { name: 'mockProjectName', description: 'Created from template @adobe/developer-console-template', platform: 'apiKey', services: [{ sdkCode: 'AssetComputeSDK', atlasPlanCode: '', licenseConfigs: [], roles: [] }, { atlasPlanCode: '', licenseConfigs: [], roles: [], sdkCode: 'PhotoshopSDK' }], templateId: 'mockTemplateId', domain: 'mockDomain', urlScheme: 'mockUrlScheme', redirectUriList: 'mockRedirectUriList', defaultRedirectUri: 'mockDefaultRedirectUri' });
+    expect(mockConsoleSDKInstance.downloadWorkspaceJson).toHaveBeenCalled();
+    expect(mockConsoleSDKInstance.downloadWorkspaceJson).toHaveBeenCalledWith('mockOrgId', 'mockProjectId', 'mockWorkspaceId');
+  });
+
+  test('should set license config for APIs if present in request body, adobeid credential type', async () => {
+    const mockTemplate = {
+      id: '56bf8211-d92d-44ef-b98b-6ee89812e1d7',
+      author: 'John doe',
+      name: '@adobe/developer-console-template',
+      description: 'Developer Console template',
+      latestVersion: '1.0.0',
+      adobeRecommended: true,
+      status: 'Approved',
+      links: {
+        consoleProject: 'https://developer-stage.adobe.com/console/projects/1234'
+      },
+      credentials: [
+        {
+          type: 'apikey',
+          flowType: 'adobeid'
+        }
+      ],
+      apis: [
+        {
+          code: 'AssetComputeSDK',
+          productProfiles: [
+            {
+              id: '123456',
+              productId: 'AB12CD34EF56',
+              name: 'Default product profile'
+            }
+          ],
+          credentialType: 'apikey',
+          flowType: 'adobeid'
+        },
+        {
+          code: 'PhotoshopSDK',
+          productProfiles: [
+            {
+              id: '123456',
+              productId: 'AB12CD34EF56',
+              name: 'Default product profile'
+            }
+          ],
+          credentialType: 'apikey',
+          flowType: 'adobeid'
+        },
+        {
+          code: 'IllustratorSDK',
+          productProfiles: [
+            {
+              id: '123456',
+              productId: 'AB12CD34EF56',
+              name: 'Default product profile'
+            }
+          ],
+          credentialType: 'oauthnativeapp',
+          flowType: 'adobeid'
+        }
+      ],
+      codeSamples: [
+        {
+          language: 'node',
+          link: 'https://developer-stage.adobe.com/sample.zip'
+        }
+      ]
+    };
+    findTemplateById.mockReturnValueOnce(mockTemplate);
+    const mockAdobeIdIntegrationResponse = {
+      body: {
+        id: 'mockId',
+        apikey: 'mockApiKey',
+        orgId: 'mockOrgId',
+        projectId: 'mockProjectId',
+        workspaceId: 'mockWorkspaceId',
+        subscriptionResult: {
+          sdkList: [],
+          errorList: []
+        }
+      }
+    };
+    mockConsoleSDKInstance.createAdobeIdIntegration.mockResolvedValue(mockAdobeIdIntegrationResponse);
+    process.env.__OW_API_HOST = 'https://controller-gw-ns-team-ethos651prodjpn3-runtime-prod-b.ethos651-prod-jpn3.ethos.adobe.net';
+    mockParams.metadata = {
+      domain: 'mockDomain',
+      urlScheme: 'mockUrlScheme',
+      redirectUriList: 'mockRedirectUriList',
+      defaultRedirectUri: 'mockDefaultRedirectUri'
+    };
+    mockParams.apis = [
+      {
+        code: 'AssetComputeSDK',
+        credentialType: 'apikey',
+        flowType: 'adobeid',
+        licenseConfigs: [
+          {
+            id: '1',
+            productId: 'A',
+            op: 'mockOp'
+          }
+        ]
+      },
+      {
+        code: 'PhotoshopSDK',
+        credentialType: 'apikey',
+        flowType: 'adobeid',
+        licenseConfigs: [
+          {
+            id: '2',
+            productId: 'B',
+            op: 'mockOp'
+          }
+        ]
+      }
+    ];
+    await action.main(mockParams);
+    expect(mockConsoleSDKInstance.createAdobeIdIntegration).toHaveBeenCalled();
+    expect(mockConsoleSDKInstance.createOauthS2SCredentialIntegration).not.toHaveBeenCalled();
+    expect(mockConsoleSDKInstance.createAdobeIdIntegration).toHaveBeenCalledWith('mockOrgId', { name: 'mockProjectName', description: 'Created from template @adobe/developer-console-template', platform: 'apiKey', services: [{ sdkCode: 'AssetComputeSDK', atlasPlanCode: '', licenseConfigs: [{ id: '1', productId: 'A', op: 'mockOp' }], roles: [] }, { atlasPlanCode: '', licenseConfigs: [{ id: '2', productId: 'B', op: 'mockOp' }], roles: [], sdkCode: 'PhotoshopSDK' }], templateId: 'mockTemplateId', domain: 'mockDomain', urlScheme: 'mockUrlScheme', redirectUriList: 'mockRedirectUriList', defaultRedirectUri: 'mockDefaultRedirectUri' });
+    expect(mockConsoleSDKInstance.downloadWorkspaceJson).toHaveBeenCalled();
+    expect(mockConsoleSDKInstance.downloadWorkspaceJson).toHaveBeenCalledWith('mockOrgId', 'mockProjectId', 'mockWorkspaceId');
+  });
+
+  test('should set license config for APIs if present in request body, entp credential type', async () => {
+    const mockTemplate = {
+      id: '56bf8211-d92d-44ef-b98b-6ee89812e1d7',
+      author: 'John doe',
+      name: '@adobe/developer-console-template',
+      description: 'Developer Console template',
+      latestVersion: '1.0.0',
+      adobeRecommended: true,
+      status: 'Approved',
+      links: {
+        consoleProject: 'https://developer-stage.adobe.com/console/projects/1234'
+      },
+      credentials: [
+        {
+          type: 'oauth_server_to_server',
+          flowType: 'entp'
+        }
+      ],
+      apis: [
+        {
+          code: 'AssetComputeSDK',
+          productProfiles: [
+            {
+              id: '123456',
+              productId: 'AB12CD34EF56',
+              name: 'Default product profile'
+            }
+          ],
+          credentialType: 'apikey',
+          flowType: 'adobeid'
+        },
+        {
+          code: 'PhotoshopSDK',
+          productProfiles: [
+            {
+              id: '123456',
+              productId: 'AB12CD34EF56',
+              name: 'Default product profile'
+            }
+          ],
+          credentialType: 'oauth_server_to_server',
+          flowType: 'entp'
+        },
+        {
+          code: 'IllustratorSDK',
+          productProfiles: [
+            {
+              id: '123456',
+              productId: 'AB12CD34EF56',
+              name: 'Default product profile'
+            }
+          ],
+          credentialType: 'oauthnativeapp',
+          flowType: 'adobeid'
+        }
+      ],
+      codeSamples: [
+        {
+          language: 'node',
+          link: 'https://developer-stage.adobe.com/sample.zip'
+        }
+      ]
+    };
+    findTemplateById.mockReturnValueOnce(mockTemplate);
+    const mockOAuthS2SIntegrationResponse = {
+      body: {
+        id: 'mockId',
+        apikey: 'mockApiKey',
+        orgId: 'mockOrgId',
+        projectId: 'mockProjectId',
+        workspaceId: 'mockWorkspaceId',
+        subscriptionResult: {
+          sdkList: [],
+          errorList: []
+        }
+      }
+    };
+    mockConsoleSDKInstance.createOauthS2SCredentialIntegration.mockResolvedValue(mockOAuthS2SIntegrationResponse);
+    process.env.__OW_API_HOST = 'https://controller-gw-ns-team-ethos651prodjpn3-runtime-prod-b.ethos651-prod-jpn3.ethos.adobe.net';
+    delete mockParams.description;
+    mockParams.apis = [
+      {
+        code: 'AssetComputeSDK',
+        credentialType: 'apikey',
+        flowType: 'adobeid',
+        licenseConfigs: [
+          {
+            id: '1',
+            productId: 'A',
+            op: 'mockOp'
+          }
+        ]
+      },
+      {
+        code: 'PhotoshopSDK',
+        credentialType: 'oauth_server_to_server',
+        flowType: 'ENTP',
+        licenseConfigs: [
+          {
+            id: '2',
+            productId: 'B',
+            op: 'mockOp'
+          }
+        ]
+      }
+    ];
+    await action.main(mockParams);
+    expect(mockConsoleSDKInstance.createAdobeIdIntegration).not.toHaveBeenCalled();
+    expect(mockConsoleSDKInstance.createOauthS2SCredentialIntegration).toHaveBeenCalled();
+    expect(mockConsoleSDKInstance.createOauthS2SCredentialIntegration).toHaveBeenCalledWith('mockOrgId', { description: 'Created from template @adobe/developer-console-template', name: 'mockProjectName', services: [{ atlasPlanCode: '', licenseConfigs: [{ id: '2', productId: 'B', op: 'mockOp' }], roles: [], sdkCode: 'PhotoshopSDK' }], templateId: 'mockTemplateId' });
     expect(mockConsoleSDKInstance.downloadWorkspaceJson).toHaveBeenCalled();
     expect(mockConsoleSDKInstance.downloadWorkspaceJson).toHaveBeenCalledWith('mockOrgId', 'mockProjectId', 'mockWorkspaceId');
   });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
There is a recent change to the Install template request body that adds a new field to include the credential type and license configs for each API. 
Thus, there is a need for code/logic addition to the Install Template endpoint to set the license configs based on this new field.
This PR adds support for the above issue.
<!--- Describe your changes in detail -->

## Related Issue
https://jira.corp.adobe.com/browse/ACNA-2973
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
