### PR TITLE
fix: remove productProfiles from template model

### DIFF
--- a/actions/templates/post/index.js
+++ b/actions/templates/post/index.js
@@ -144,8 +144,7 @@ async function main (params) {
             return {
               credentialType: credential.type,
               flowType: credential.flowType,
-              code: api.code,
-              productProfiles: api?.productProfiles
+              code: api.code
             };
           }));
         }

--- a/actions/templates/put/index.js
+++ b/actions/templates/put/index.js
@@ -131,8 +131,7 @@ async function main (params) {
             return {
               credentialType: credential.type,
               flowType: credential.flowType,
-              code: api.code,
-              productProfiles: api?.productProfiles
+              code: api.code
             };
           }));
         }

--- a/test/templates.install.test.js
+++ b/test/templates.install.test.js
@@ -226,13 +226,6 @@ describe('POST Install template: Core business logic specific tests', () => {
       apis: [
         {
           code: 'AssetComputeSDK',
-          productProfiles: [
-            {
-              id: '123456',
-              productId: 'AB12CD34EF56',
-              name: 'Default product profile'
-            }
-          ],
           credentialType: 'apikey',
           flowType: 'adobeid'
         }
@@ -248,7 +241,7 @@ describe('POST Install template: Core business logic specific tests', () => {
     findTemplateById.mockReturnValueOnce(mockTemplate);
     await action.main(mockParams);
     expect(Core.Logger().debug).toHaveBeenNthCalledWith(3, 'Credentials found: [{"type":"apikey","flowtype":"adobeid"}]');
-    expect(Core.Logger().debug).toHaveBeenNthCalledWith(4, 'APIs found: [{"code":"AssetComputeSDK","productProfiles":[{"id":"123456","productId":"AB12CD34EF56","name":"Default product profile"}],"credentialType":"apikey","flowType":"adobeid"}]');
+    expect(Core.Logger().debug).toHaveBeenNthCalledWith(4, 'APIs found: [{"code":"AssetComputeSDK","credentialType":"apikey","flowType":"adobeid"}]');
   });
 
   test('should initialize console lib with correct parameters', async () => {
@@ -281,37 +274,16 @@ describe('POST Install template: Core business logic specific tests', () => {
       apis: [
         {
           code: 'AssetComputeSDK',
-          productProfiles: [
-            {
-              id: '123456',
-              productId: 'AB12CD34EF56',
-              name: 'Default product profile'
-            }
-          ],
           credentialType: 'apikey',
           flowType: 'adobeid'
         },
         {
           code: 'PhotoshopSDK',
-          productProfiles: [
-            {
-              id: '123456',
-              productId: 'AB12CD34EF56',
-              name: 'Default product profile'
-            }
-          ],
           credentialType: 'oauth_server_to_server',
           flowType: 'entp'
         },
         {
           code: 'IllustratorSDK',
-          productProfiles: [
-            {
-              id: '123456',
-              productId: 'AB12CD34EF56',
-              name: 'Default product profile'
-            }
-          ],
           credentialType: 'oauthnativeapp',
           flowType: 'adobeid'
         }
@@ -367,37 +339,16 @@ describe('POST Install template: Core business logic specific tests', () => {
       apis: [
         {
           code: 'AssetComputeSDK',
-          productProfiles: [
-            {
-              id: '123456',
-              productId: 'AB12CD34EF56',
-              name: 'Default product profile'
-            }
-          ],
           credentialType: 'apikey',
           flowType: 'adobeid'
         },
         {
           code: 'PhotoshopSDK',
-          productProfiles: [
-            {
-              id: '123456',
-              productId: 'AB12CD34EF56',
-              name: 'Default product profile'
-            }
-          ],
           credentialType: 'oauth_server_to_server',
           flowType: 'entp'
         },
         {
           code: 'IllustratorSDK',
-          productProfiles: [
-            {
-              id: '123456',
-              productId: 'AB12CD34EF56',
-              name: 'Default product profile'
-            }
-          ],
           credentialType: 'oauthnativeapp',
           flowType: 'adobeid'
         }
@@ -453,37 +404,16 @@ describe('POST Install template: Core business logic specific tests', () => {
       apis: [
         {
           code: 'AssetComputeSDK',
-          productProfiles: [
-            {
-              id: '123456',
-              productId: 'AB12CD34EF56',
-              name: 'Default product profile'
-            }
-          ],
           credentialType: 'apikey',
           flowType: 'adobeid'
         },
         {
           code: 'PhotoshopSDK',
-          productProfiles: [
-            {
-              id: '123456',
-              productId: 'AB12CD34EF56',
-              name: 'Default product profile'
-            }
-          ],
           credentialType: 'apikey',
           flowType: 'adobeid'
         },
         {
           code: 'IllustratorSDK',
-          productProfiles: [
-            {
-              id: '123456',
-              productId: 'AB12CD34EF56',
-              name: 'Default product profile'
-            }
-          ],
           credentialType: 'oauthnativeapp',
           flowType: 'adobeid'
         }
@@ -545,37 +475,16 @@ describe('POST Install template: Core business logic specific tests', () => {
       apis: [
         {
           code: 'AssetComputeSDK',
-          productProfiles: [
-            {
-              id: '123456',
-              productId: 'AB12CD34EF56',
-              name: 'Default product profile'
-            }
-          ],
           credentialType: 'apikey',
           flowType: 'adobeid'
         },
         {
           code: 'PhotoshopSDK',
-          productProfiles: [
-            {
-              id: '123456',
-              productId: 'AB12CD34EF56',
-              name: 'Default product profile'
-            }
-          ],
           credentialType: 'apikey',
           flowType: 'adobeid'
         },
         {
           code: 'IllustratorSDK',
-          productProfiles: [
-            {
-              id: '123456',
-              productId: 'AB12CD34EF56',
-              name: 'Default product profile'
-            }
-          ],
           credentialType: 'oauthnativeapp',
           flowType: 'adobeid'
         }
@@ -637,13 +546,6 @@ describe('POST Install template: Core business logic specific tests', () => {
       apis: [
         {
           code: 'AssetComputeSDK',
-          productProfiles: [
-            {
-              id: '123456',
-              productId: 'AB12CD34EF56',
-              name: 'Default product profile'
-            }
-          ],
           credentialType: 'apikey',
           flowType: 'analytics'
         }
@@ -682,37 +584,16 @@ describe('POST Install template: Core business logic specific tests', () => {
       apis: [
         {
           code: 'AssetComputeSDK',
-          productProfiles: [
-            {
-              id: '123456',
-              productId: 'AB12CD34EF56',
-              name: 'Default product profile'
-            }
-          ],
           credentialType: 'apikey',
           flowType: 'adobeid'
         },
         {
           code: 'PhotoshopSDK',
-          productProfiles: [
-            {
-              id: '123456',
-              productId: 'AB12CD34EF56',
-              name: 'Default product profile'
-            }
-          ],
           credentialType: 'apikey',
           flowType: 'adobeid'
         },
         {
           code: 'IllustratorSDK',
-          productProfiles: [
-            {
-              id: '123456',
-              productId: 'AB12CD34EF56',
-              name: 'Default product profile'
-            }
-          ],
           credentialType: 'oauthnativeapp',
           flowType: 'adobeid'
         }
@@ -754,37 +635,16 @@ describe('POST Install template: Core business logic specific tests', () => {
       apis: [
         {
           code: 'AssetComputeSDK',
-          productProfiles: [
-            {
-              id: '123456',
-              productId: 'AB12CD34EF56',
-              name: 'Default product profile'
-            }
-          ],
           credentialType: 'apikey',
           flowType: 'adobeid'
         },
         {
           code: 'PhotoshopSDK',
-          productProfiles: [
-            {
-              id: '123456',
-              productId: 'AB12CD34EF56',
-              name: 'Default product profile'
-            }
-          ],
           credentialType: 'apikey',
           flowType: 'adobeid'
         },
         {
           code: 'IllustratorSDK',
-          productProfiles: [
-            {
-              id: '123456',
-              productId: 'AB12CD34EF56',
-              name: 'Default product profile'
-            }
-          ],
           credentialType: 'oauthnativeapp',
           flowType: 'adobeid'
         }
@@ -838,37 +698,16 @@ describe('POST Install template: Core business logic specific tests', () => {
       apis: [
         {
           code: 'AssetComputeSDK',
-          productProfiles: [
-            {
-              id: '123456',
-              productId: 'AB12CD34EF56',
-              name: 'Default product profile'
-            }
-          ],
           credentialType: 'APIKEY',
           flowType: 'ADOBEID'
         },
         {
           code: 'PhotoshopSDK',
-          productProfiles: [
-            {
-              id: '123456',
-              productId: 'AB12CD34EF56',
-              name: 'Default product profile'
-            }
-          ],
           credentialType: 'APIKEY',
           flowType: 'ADOBEID'
         },
         {
           code: 'IllustratorSDK',
-          productProfiles: [
-            {
-              id: '123456',
-              productId: 'AB12CD34EF56',
-              name: 'Default product profile'
-            }
-          ],
           credentialType: 'OAUTHNATIVEAPP',
           flowType: 'ADOBEID'
         }
@@ -930,37 +769,17 @@ describe('POST Install template: Core business logic specific tests', () => {
       apis: [
         {
           code: 'AssetComputeSDK',
-          productProfiles: [
-            {
-              id: '123456',
-              productId: 'AB12CD34EF56',
-              name: 'Default product profile'
-            }
-          ],
           credentialType: 'apikey',
           flowType: 'adobeid'
         },
         {
           code: 'PhotoshopSDK',
-          productProfiles: [
-            {
-              id: '123456',
-              productId: 'AB12CD34EF56',
-              name: 'Default product profile'
-            }
-          ],
+
           credentialType: 'apikey',
           flowType: 'adobeid'
         },
         {
           code: 'IllustratorSDK',
-          productProfiles: [
-            {
-              id: '123456',
-              productId: 'AB12CD34EF56',
-              name: 'Default product profile'
-            }
-          ],
           credentialType: 'oauthnativeapp',
           flowType: 'adobeid'
         }
@@ -1047,37 +866,16 @@ describe('POST Install template: Core business logic specific tests', () => {
       apis: [
         {
           code: 'AssetComputeSDK',
-          productProfiles: [
-            {
-              id: '123456',
-              productId: 'AB12CD34EF56',
-              name: 'Default product profile'
-            }
-          ],
           credentialType: 'apikey',
           flowType: 'adobeid'
         },
         {
           code: 'PhotoshopSDK',
-          productProfiles: [
-            {
-              id: '123456',
-              productId: 'AB12CD34EF56',
-              name: 'Default product profile'
-            }
-          ],
           credentialType: 'oauth_server_to_server',
           flowType: 'entp'
         },
         {
           code: 'IllustratorSDK',
-          productProfiles: [
-            {
-              id: '123456',
-              productId: 'AB12CD34EF56',
-              name: 'Default product profile'
-            }
-          ],
           credentialType: 'oauthnativeapp',
           flowType: 'adobeid'
         }

--- a/test/templates.post.test.js
+++ b/test/templates.post.test.js
@@ -394,8 +394,7 @@ describe('POST templates', () => {
         {
           credentialType: 'serviceAccount',
           flowType: 'oauth2',
-          code: 'AdobeIO',
-          productProfiles: undefined
+          code: 'AdobeIO'
         }
       ],
       credentials: [
@@ -585,8 +584,7 @@ describe('POST templates', () => {
         {
           credentialType: 'serviceAccount',
           flowType: 'oauth2',
-          code: 'AdobeIO',
-          productProfiles: undefined
+          code: 'AdobeIO'
         }
       ],
       credentials: [
@@ -690,8 +688,7 @@ describe('POST templates', () => {
         {
           credentialType: 'serviceAccount',
           flowType: 'oauth2',
-          code: 'AdobeIO',
-          productProfiles: undefined
+          code: 'AdobeIO'
         }
       ],
       credentials: [

--- a/test/templates.put.test.js
+++ b/test/templates.put.test.js
@@ -502,14 +502,7 @@ describe('PUT templates', () => {
             flowType: 'fake-flowType',
             apis: [
               {
-                code: 'fake-code',
-                productProfiles: [
-                  {
-                    id: 'fake-id',
-                    productId: 'fake-productId',
-                    name: 'fake-name'
-                  }
-                ]
+                code: 'fake-code'
               }
             ]
           }
@@ -534,14 +527,7 @@ describe('PUT templates', () => {
       apis: [{
         credentialType: 'fake-type',
         flowType: 'fake - flowType',
-        code: 'fake-code',
-        productProfiles: [
-          {
-            id: 'fake-id',
-            productId: 'fake-productId',
-            name: 'fake-name'
-          }
-        ]
+        code: 'fake-code'
       }]
     };
     findTemplateById.mockReturnValue(template);
@@ -612,14 +598,7 @@ describe('PUT templates', () => {
       apis: [{
         credentialType: 'fake-type',
         flowType: 'fake - flowType',
-        code: 'fake-code',
-        productProfiles: [
-          {
-            id: 'fake-id',
-            productId: 'fake-productId',
-            name: 'fake-name'
-          }
-        ]
+        code: 'fake-code'
       }]
     };
     findTemplateById.mockReturnValue(template);


### PR DESCRIPTION
## Description

`apis.productProfiles` should't be stored in the template record anymore, this info is now provided in the request body when users call the install endpoint

Note: Any dev console templates made in stage that include this field will have to be re-created without the field for it to be omitted from the get and list responses (No code was added to explicitly omit this field since we're not in prod yet and once this change is pulled in, a template could never include it...) 

## Related Issue

## Motivation and Context

## How Has This Been Tested?

changes deployed to test service, `npm run test`

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
