### PR TITLE
fix: unreachable urls included in _links.self.href

### DIFF
--- a/actions/templates/get/index.js
+++ b/actions/templates/get/index.js
@@ -43,10 +43,12 @@ async function fetchTemplateById (params, dbParams, logger) {
     ...template,
     _links: {
       self: {
-        href: `${params.TEMPLATE_REGISTRY_API_URL}/templates/${template.name}`
+        href: `${params.TEMPLATE_REGISTRY_API_URL}/templates/${template.id}`
       }
     }
   };
+
+  // dev console templates are auto-approved by default, so this block will only be true for app builder templates
   const templateStatuses = [TEMPLATE_STATUS_IN_VERIFICATION, TEMPLATE_STATUS_REJECTED];
   if (templateStatuses.includes(template.status)) {
     const reviewIssue = await getReviewIssueByTemplateName(template.name, params.TEMPLATE_REGISTRY_ORG, params.TEMPLATE_REGISTRY_REPOSITORY);
@@ -90,6 +92,8 @@ async function fetchTemplateByName (params, dbParams, logger) {
       }
     }
   };
+
+  // dev console templates are auto-approved by default, so this block will only be true for app builder templates
   const templateStatuses = [TEMPLATE_STATUS_IN_VERIFICATION, TEMPLATE_STATUS_REJECTED];
   if (templateStatuses.includes(template.status)) {
     const reviewIssue = await getReviewIssueByTemplateName(fullTemplateName, params.TEMPLATE_REGISTRY_ORG, params.TEMPLATE_REGISTRY_REPOSITORY);

--- a/actions/templates/list/index.js
+++ b/actions/templates/list/index.js
@@ -207,10 +207,13 @@ async function main (params) {
         ...templates[i],
         _links: {
           self: {
-            href: `${params.TEMPLATE_REGISTRY_API_URL}/templates/${templates[i].name}`
+            // if name is npm package name (i.e. @adobe/template), then use the name, otherwise use the id
+            href: templates[i].name.includes('/') ? `${params.TEMPLATE_REGISTRY_API_URL}/templates/${templates[i].name}` : `${params.TEMPLATE_REGISTRY_API_URL}/templates/${templates[i].id}`
           }
         }
       };
+
+      // dev console templates are auto-approved by default, so this block will only be true for app builder templates
       const templateStatuses = [TEMPLATE_STATUS_IN_VERIFICATION, TEMPLATE_STATUS_REJECTED];
       if (templateStatuses.includes(templates[i].status)) {
         const reviewIssue = await getReviewIssueByTemplateName(templates[i].name, params.TEMPLATE_REGISTRY_ORG, params.TEMPLATE_REGISTRY_REPOSITORY);

--- a/actions/templates/post/index.js
+++ b/actions/templates/post/index.js
@@ -165,7 +165,8 @@ async function main (params) {
       ...template,
       _links: {
         self: {
-          href: `${params.TEMPLATE_REGISTRY_API_URL}/templates/${templateName}`
+          // if name is npm package name (i.e. @adobe/template), then use the name, otherwise use the id
+          href: template.name.includes('/') ? `${params.TEMPLATE_REGISTRY_API_URL}/templates/${template.name}` : `${params.TEMPLATE_REGISTRY_API_URL}/templates/${template.id}`
         }
         // TODO: Uncomment this when we support App Builder templates again
         // 'review': {

--- a/actions/templates/put/index.js
+++ b/actions/templates/put/index.js
@@ -157,7 +157,8 @@ async function main (params) {
       ...template,
       _links: {
         self: {
-          href: `${params.TEMPLATE_REGISTRY_API_URL}/templates/${template?.name}`
+          // if name is npm package name (i.e. @adobe/template), then use the name, otherwise use the id
+          href: template.name.includes('/') ? `${params.TEMPLATE_REGISTRY_API_URL}/templates/${template.name}` : `${params.TEMPLATE_REGISTRY_API_URL}/templates/${template.id}`
         }
       }
     };

--- a/test/fixtures/list/registry-with-dev-console.json
+++ b/test/fixtures/list/registry-with-dev-console.json
@@ -19,7 +19,7 @@
     },
     {
         "id": "d1dc1000-f32e-4172-a0ac-9b2f3ef6ac48",
-        "name": "@author/app-builder-template-6",
+        "name": "app-builder-template-6",
         "status": "Rejected",
         "links": {
             "consoleProject": "https://developer-stage.adobe.com/console/projects/1234"

--- a/test/fixtures/list/response.with-dev-console-templates.json
+++ b/test/fixtures/list/response.with-dev-console-templates.json
@@ -50,11 +50,11 @@
                         "href": "https://github.com/adobe/aio-templates/issues/100"
                     },
                     "self": {
-                        "href": "https://template-registry-api.tbd/apis/v1/templates/@author/app-builder-template-6"
+                        "href": "https://template-registry-api.tbd/apis/v1/templates/d1dc1000-f32e-4172-a0ac-9b2f3ef6ac48"
                     }
                 },
                 "id": "d1dc1000-f32e-4172-a0ac-9b2f3ef6ac48",
-                "name": "@author/app-builder-template-6",
+                "name": "app-builder-template-6",
                 "status": "Rejected",
                 "links": {
                     "consoleProject": "https://developer-stage.adobe.com/console/projects/1234"

--- a/test/templates.get.test.js
+++ b/test/templates.get.test.js
@@ -418,7 +418,7 @@ describe('GET templates', () => {
         ...template,
         _links: {
           self: {
-            href: `${process.env.TEMPLATE_REGISTRY_API_URL}/templates/${fullTemplateName}`
+            href: `${process.env.TEMPLATE_REGISTRY_API_URL}/templates/${templateId}`
           }
         }
       }
@@ -457,7 +457,7 @@ describe('GET templates', () => {
         ...template,
         _links: {
           self: {
-            href: `${process.env.TEMPLATE_REGISTRY_API_URL}/templates/${fullTemplateName}`
+            href: `${process.env.TEMPLATE_REGISTRY_API_URL}/templates/${templateId}`
           },
           review: {
             href: reviewIssue,
@@ -500,7 +500,7 @@ describe('GET templates', () => {
         ...template,
         _links: {
           self: {
-            href: `${process.env.TEMPLATE_REGISTRY_API_URL}/templates/${fullTemplateName}`
+            href: `${process.env.TEMPLATE_REGISTRY_API_URL}/templates/${templateId}`
           }
         }
       }

--- a/test/templates.post.test.js
+++ b/test/templates.post.test.js
@@ -635,7 +635,7 @@ describe('POST templates', () => {
 
     findTemplateByName.mockReturnValue(null);
     fetchUrl.mockReturnValue('');
-    const templateName = '@adobe/developer-console-template';
+    const templateName = 'developer-console-template';
     const template = {
       id: '56bf8211-d92d-44ef-b98b-6ee89812e1d7',
       name: templateName,
@@ -675,7 +675,7 @@ describe('POST templates', () => {
         ...template,
         _links: {
           self: {
-            href: `${process.env.TEMPLATE_REGISTRY_API_URL}/templates/${templateName}`
+            href: `${process.env.TEMPLATE_REGISTRY_API_URL}/templates/${template.id}`
           }
         }
       }

--- a/test/templates.put.test.js
+++ b/test/templates.put.test.js
@@ -308,7 +308,10 @@ describe('PUT templates', () => {
 
   test('Incorrect response, should throw error', async () => {
     fetchUrl.mockReturnValue('');
-    findTemplateById.mockReturnValue(null);
+    findTemplateById.mockReturnValue({
+      name: 'fake-template-name',
+      bad: 'field'
+    });
     updateTemplate.mockReturnValue({ matchedCount: 1 });
     const response = await action.main({
       IMS_URL: process.env.IMS_URL,


### PR DESCRIPTION
## Description

Currently the `_links.self.href` field will always be a link with the template's name: 
```
{
    "_links": {
        "self": {
            "href": "<baseUrl>/templates/test-template-3"
        }
    },
    ... rest of template
}
```

But since we changed `GET /templates/{templateName}` to `GET /templates/{templateId}`, this won't always work. For example, the link above will try to fetch a template with an ID of `test-template-3` which doesn't exist

However, this does work when the template is an app builder template (i.e. has a name of `@adobe/template` or something similar), because we still have the `GET templates/{orgName}/{templateName}` path

This PR proposes changing this field to behave the following way: 
- When getting template by id, always return a link to the template by id
- When getting template by name, always return a link to the template by name 
- When creating, updating, or listing templates, if the name includes a `/`, return the get template by org + name link, otherwise return link to the template by id

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

changes deployed to test service, `npm run test`

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
