### PR TITLE
feat: ACNA-3007- update post templates action/endpoint to bypass install config

### DIFF
--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -37,12 +37,12 @@ jobs:
           IMS_SCOPES: ${{ secrets.IMS_SCOPES }}
           TEMPLATE_REGISTRY_API_URL: ${{ secrets.TEMPLATE_REGISTRY_API_URL }}
         run: npm run test:smoke
-      - id: slacknotification
-        name: Slack Notification
-        if: ${{ failure() }}
-        uses: rtCamp/action-slack-notify@v2
-        env:
-          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
-          SLACK_TITLE: 'Node version'
-          SLACK_MESSAGE: ${{ matrix.node-version }}
-          SLACK_COLOR: ${{ job.status == 'success' && 'good' || job.status == 'cancelled' && '#808080' || 'danger' }}
+      # - id: slacknotification
+      #   name: Slack Notification
+      #   if: ${{ failure() }}
+      #   uses: rtCamp/action-slack-notify@v2
+      #   env:
+      #     SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+      #     SLACK_TITLE: 'Node version'
+      #     SLACK_MESSAGE: ${{ matrix.node-version }}
+      #     SLACK_COLOR: ${{ job.status == 'success' && 'good' || job.status == 'cancelled' && '#808080' || 'danger' }}

--- a/actions/templates/post/index.js
+++ b/actions/templates/post/index.js
@@ -10,7 +10,7 @@ governing permissions and limitations under the License.
 */
 
 const { Core } = require('@adobe/aio-sdk');
-const { errorResponse, errorMessage, getBearerToken, stringParameters, checkMissingRequestInputs, ERR_RC_SERVER_ERROR, ERR_RC_HTTP_METHOD_NOT_ALLOWED, ERR_RC_INVALID_IMS_ACCESS_TOKEN, ERR_RC_INCORRECT_REQUEST } =
+const { errorResponse, errorMessage, getBearerToken, stringParameters, checkMissingRequestInputs, getEnv, ERR_RC_SERVER_ERROR, ERR_RC_HTTP_METHOD_NOT_ALLOWED, ERR_RC_INVALID_IMS_ACCESS_TOKEN, ERR_RC_INCORRECT_REQUEST } =
   require('../../utils');
 const { validateAccessToken, generateAccessToken } = require('../../ims');
 const { findTemplateByName, addTemplate } = require('../../templateRegistry');
@@ -126,7 +126,7 @@ async function main (params) {
     if (consoleProjectUrl) {
       const projectId = consoleProjectUrl.split('/').at(-2);
       const accessToken = await generateAccessToken(params.IMS_AUTH_CODE, params.IMS_CLIENT_ID, params.IMS_CLIENT_SECRET, params.IMS_SCOPES, logger);
-      const consoleClient = await consoleLib.init(accessToken, params.IMS_CLIENT_ID, 'stage'); // Dev console templates can only be added from stage
+      const consoleClient = await consoleLib.init(accessToken, params.IMS_CLIENT_ID, getEnv(logger));
       const { body: installConfig } = await consoleClient.getProjectInstallConfig(projectId);
 
       // We have to get the install config in this format to maintain backwards

--- a/actions/templates/post/index.js
+++ b/actions/templates/post/index.js
@@ -137,12 +137,11 @@ async function main (params) {
       };
     }
 
-    const hasCredentialsOrApiInParams = (('credentials' in params && params.credentials.length > 0) || ('apis' in params && params.apis.length > 0));
-    let template = null;
+    const hasCredentialsOrApisInParams = (('credentials' in params && params.credentials.length > 0) || ('apis' in params && params.apis.length > 0));
 
-    if (hasCredentialsOrApiInParams) {
+    if (hasCredentialsOrApisInParams) {
       // scenario 1 :  if apis or credentials are provided, skip the get install config step and just save the provided template
-      template = await addTemplate(dbParams, body);
+      // do nothing
     } else if (consoleProjectUrl) {
       // scenario 2 :  if consoleProject in payload, replace apis and credentials with the ones from the install config
       const projectId = consoleProjectUrl.split('/').at(-2);
@@ -177,9 +176,9 @@ async function main (params) {
         credentials,
         apis
       };
-      template = await addTemplate(dbParams, body);
     }
 
+    const template = await addTemplate(dbParams, body);
     // TODO: Uncomment this when we support App Builder templates again
     // const issueNumber = await createReviewIssue(templateName, githubRepoUrl, params.ACCESS_TOKEN_GITHUB, params.TEMPLATE_REGISTRY_ORG, params.TEMPLATE_REGISTRY_REPOSITORY);
     const response = {

--- a/actions/templates/post/index.js
+++ b/actions/templates/post/index.js
@@ -34,7 +34,7 @@ const serializeRequestBody = (params) => {
     ...(params.updatedBy && { updatedBy: params.updatedBy }),
     ...(params.author && { author: params.author }), // developer console only
     ...(params.status && { status: params.status }), // developer console only
-    ...(params.adobeRecommended && { adobeRecommended: params.adobeRecommended }), // developer console only
+    ...(params.adobeRecommended != null && { adobeRecommended: params.adobeRecommended }), // developer console only
     ...(params.codeSamples && { codeSamples: params.codeSamples }), // developer console only
     ...(params.requestAccessAppId && { requestAccessAppId: params.requestAccessAppId }), // developer console only
     links: {
@@ -46,13 +46,13 @@ const serializeRequestBody = (params) => {
     ...(params.extensions && params.extensions.length && { extensions: params.extensions }),
     ...(params.credentials && params.credentials.length && { credentials: params.credentials }),
     ...(params.apis && params.apis.length && { apis: params.apis }),
-    ...(params.runtime && { runtime: params.runtime }),
+    ...(params.runtime != null && { runtime: params.runtime }),
     ...(params.publishDate && { publishDate: params.publishDate }),
-    ...(params.events && params.events.length && { events: params.events }),
-    ...(params.isRequestPending && { isRequestPending: params.isRequestPending }),
-    ...(params.orgEntitled && { orgEntitled: params.orgEntitled }),
-    ...(params.userEntitled && { userEntitled: params.userEntitled }),
-    ...(params.canRequestAccess && { canRequestAccess: params.canRequestAccess }),
+    ...(params.event && { event: params.event }),
+    ...(params.isRequestPending != null && { isRequestPending: params.isRequestPending }),
+    ...(params.orgEntitled != null && { orgEntitled: params.orgEntitled }),
+    ...(params.userEntitled != null && { userEntitled: params.userEntitled }),
+    ...(params.canRequestAccess != null && { canRequestAccess: params.canRequestAccess }),
     ...(params.disEntitledReasons && params.disEntitledReasons.length && { disEntitledReasons: params.disEntitledReasons })
   };
 };
@@ -141,7 +141,7 @@ async function main (params) {
 
     if (hasCredentialsOrApisInParams) {
       // scenario 1 :  if apis or credentials are provided, skip the get install config step and just save the provided template
-      // do nothing
+      // do nothing here
     } else if (consoleProjectUrl) {
       // scenario 2 :  if consoleProject in payload, replace apis and credentials with the ones from the install config
       const projectId = consoleProjectUrl.split('/').at(-2);

--- a/template-registry-api.json
+++ b/template-registry-api.json
@@ -315,12 +315,13 @@
                         "description": "The sdk code of the service",
                         "example": "AdobeAnalyticsSDK"
                       },
-                      "licenseConfigs": {
-                        "type": "array",
-                        "description": "List of available license configs (product profiles) for the API",
-                        "items": {
-                          "type": "object"
-                        }
+                      "credentialType": {
+                        "type": "string",
+                        "description": "Credential type"
+                      },
+                      "flowType": {
+                        "type": "string",
+                        "description": "Flow type"
                       }
                     }
                   }
@@ -1115,12 +1116,13 @@
                 "description": "The sdk code of the service",
                 "example": "AdobeAnalyticsSDK"
               },
-              "licenseConfigs": {
-                "type": "array",
-                "description": "List of available license configs (product profiles) for the API",
-                "items": {
-                  "type": "object"
-                }
+              "credentialType": {
+                "type": "string",
+                "description": "Credential type"
+              },
+              "flowType": {
+                "type": "string",
+                "description": "Flow type"
               }
             }
           }
@@ -1383,7 +1385,7 @@
                 "type": "string",
                 "description": "Credential type"
               },
-              "FlowType": {
+              "flowType": {
                 "type": "string",
                 "description": "Flow type"
               },

--- a/template-registry-api.json
+++ b/template-registry-api.json
@@ -399,6 +399,8 @@
                   "type": "object",
                   "description": "A list of locations where the package's code can be found",
                   "additionalProperties": false,
+                  "minProperties": 1,
+                  "x-nullable": false,
                   "properties": {
                     "npm": {
                       "type": "string",
@@ -442,9 +444,6 @@
                     "USER_MISSING_PRIVATE_BETA",
                     "USER_MISSING_PUBLIC_BETA"
                   ]
-                },
-                "_links": {
-                  "$ref": "#/definitions/Links"
                 }
               },
               "example": {

--- a/template-registry-api.json
+++ b/template-registry-api.json
@@ -230,29 +230,145 @@
               "properties": {
                 "name": {
                   "type": "string",
-                  "description": "The name of the package implementing the template on npmjs.com",
+                  "description": "The name of the template on npmjs.com",
                   "example": "@adobe/app-builder-template",
                   "x-nullable": false
                 },
-                "description": {
+                "author": {
                   "type": "string",
-                  "description": "A description of the template",
-                  "example": "This is a template for Adobe App Builder"
+                  "description": "The name of the template's author on npmjs.com",
+                  "example": "Adobe Inc."
                 },
                 "createdBy": {
                   "type": "string",
                   "description": "The name of the user who created the template",
                   "example": "Lazarus"
                 },
+                "updatedBy": {
+                  "type": "string",
+                  "description": "The name of the user who last updated the template",
+                  "example": "Lazarus"
+                },
+                "description": {
+                  "type": "string",
+                  "description": "A description of the template",
+                  "example": "AppBuilder template"
+                },
+                "adobeRecommended": {
+                  "type": "boolean",
+                  "description": "Whether the template is recommended by Adobe",
+                  "example": true
+                },
                 "latestVersion": {
                   "type": "string",
                   "description": "The version of the template in the semver format",
-                  "example": "1.0.0"
+                  "example": "1.0.10"
                 },
-                "author": {
+                "publishDate": {
                   "type": "string",
-                  "description": "The name of the template's author",
-                  "example": "Adobe Inc."
+                  "description": "The date the template was published in the ISO 8601 format",
+                  "example": "2022-04-20T19:54:41.495Z"
+                },
+                "extensions": {
+                  "type": "array",
+                  "description": "Extension points that a template implements",
+                  "minItems": 1,
+                  "items": {
+                    "type": "object",
+                    "required": [
+                      "extensionPointId"
+                    ],
+                    "additionalProperties": true,
+                    "properties": {
+                      "extensionPointId": {
+                        "type": "string",
+                        "description": "Extension Point Id",
+                        "example": "dx/excshell/1"
+                      }
+                    }
+                  }
+                },
+                "categories": {
+                  "type": "array",
+                  "description": "A list of categories the template belongs to",
+                  "minItems": 1,
+                  "items": {
+                    "type": "string"
+                  },
+                  "example": [
+                    "graphql-mesh"
+                  ]
+                },
+                "apis": {
+                  "type": "array",
+                  "description": "A list of Adobe APIs required by the template",
+                  "minItems": 1,
+                  "items": {
+                    "type": "object",
+                    "required": [
+                      "code"
+                    ],
+                    "additionalProperties": true,
+                    "properties": {
+                      "code": {
+                        "type": "string",
+                        "description": "The sdk code of the service",
+                        "example": "AdobeAnalyticsSDK"
+                      },
+                      "licenseConfigs": {
+                        "type": "array",
+                        "description": "List of available license configs (product profiles) for the API",
+                        "items": {
+                          "type": "object"
+                        }
+                      }
+                    }
+                  }
+                },
+                "credentials": {
+                  "type": "array",
+                  "description": "A list of credentials required by the template",
+                  "minItems": 1,
+                  "items": {
+                    "type": "object",
+                    "required": [
+                      "type",
+                      "flowType"
+                    ],
+                    "additionalProperties": true,
+                    "properties": {
+                      "type": {
+                        "type": "string",
+                        "description": "The type of the credential",
+                        "example": "OAUTH_SERVER_TO_SERVER"
+                      },
+                      "flowType": {
+                        "type": "string",
+                        "description": "The flow type of the credential",
+                        "example": "ENTP"
+                      }
+                    }
+                  }
+                },
+                "runtime": {
+                  "type": "boolean",
+                  "description": "Whether to add Runtime to App Builder application or not.",
+                  "default": false
+                },
+                "event": {
+                  "type": "object",
+                  "description": "event configuration for the template"
+                },
+                "keywords": {
+                  "type": "array",
+                  "description": "A list of keywords specified in the packages.json file",
+                  "items": {
+                    "type": "string"
+                  },
+                  "example": [
+                    "aio-app-builder-template",
+                    "aio"
+                  ]
                 },
                 "status": {
                   "type": "string",
@@ -265,11 +381,6 @@
                   ],
                   "example": "Approved"
                 },
-                "adobeRecommended": {
-                  "type": "boolean",
-                  "description": "Whether the template is recommended by Adobe",
-                  "example": true
-                },
                 "codeSamples": {
                   "$ref": "#/definitions/CodeSamples"
                 },
@@ -278,13 +389,23 @@
                   "description": "Access Platform app id which can be used to request access to services in this template.",
                   "example": "FireflySDKEnterprise1"
                 },
+                "isRequestPending": {
+                  "type": "boolean",
+                  "description": "Indicates whether a request for access is already pending for the user in a given org",
+                  "example": "true"
+                },
                 "links": {
                   "type": "object",
-                  "description": "A link to the Github repository containing the package's source code",
+                  "description": "A list of locations where the package's code can be found",
                   "additionalProperties": false,
-                  "minProperties": 1,
-                  "x-nullable": false,
                   "properties": {
+                    "npm": {
+                      "type": "string",
+                      "format": "uri",
+                      "pattern": "^https://www\\.npmjs\\.com/",
+                      "description": "A link to the package on npmjs.com",
+                      "example": "https://www.npmjs.com/package/@adobe/app-builder-template"
+                    },
                     "github": {
                       "$ref": "#/definitions/GithubUrl"
                     },
@@ -292,6 +413,37 @@
                       "$ref": "#/definitions/DeveloperConsoleUrl"
                     }
                   }
+                },
+                "orgEntitled": {
+                  "type": "boolean",
+                  "description": "Whether the organization is entitled to use the template",
+                  "example": true
+                },
+                "userEntitled": {
+                  "type": "boolean",
+                  "description": "Whether the user is entitled to use the template",
+                  "example": true
+                },
+                "canRequestAccess": {
+                  "type": "boolean",
+                  "description": "Whether the user can request access to the template",
+                  "example": true
+                },
+                "disEntitledReasons": {
+                  "type": "array",
+                  "description": "A list of reasons why the user is not entitled to use the template",
+                  "items": {
+                    "type": "string"
+                  },
+                  "example": [
+                    "USER_MISSING_DEV_ROLE",
+                    "ORG_MISSING_FIS",
+                    "USER_MISSING_PRIVATE_BETA",
+                    "USER_MISSING_PUBLIC_BETA"
+                  ]
+                },
+                "_links": {
+                  "$ref": "#/definitions/Links"
                 }
               },
               "example": {

--- a/test/templates.post.test.js
+++ b/test/templates.post.test.js
@@ -843,4 +843,271 @@ describe('POST templates', () => {
       }
     });
   });
+
+  test('Adding new developer console template with more additional fields, should return 200', async () => {
+    findTemplateByName.mockReturnValue(null);
+    fetchUrl.mockReturnValue('');
+    const templateName = '@adobe/developer-console-template';
+    const template = {
+      id: '56bf8211-d92d-44ef-b98b-6ee89812e1d7',
+      name: templateName,
+      description: 'Developer Console template',
+      latestVersion: '1.0.0',
+      createdBy: 'Capernicus',
+      links: {
+        consoleProject: DEVELOPER_CONSOLE_PROJECT
+      },
+      author: 'Capernicus',
+      adobeRecommended: true,
+      status: 'Approved',
+      codeSamples: [
+        {
+          language: 'node',
+          link: 'https://developer-stage.adobe.com/sample.zip'
+        }
+      ],
+      requestAccessAppId: 'requestAccessAppId',
+      updatedBy: 'Capernicus',
+      keywords: ['Developer Console'],
+      categories: ['Templates'],
+      extensions: [{ extensionPointId: 'mockExtension' }],
+      credentials: [{ type: 'serviceAccount', flowType: 'oauth2' }],
+      apis: [{ credentialType: 'serviceAccount', flowType: 'oauth2', code: 'AdobeIO' }],
+      runtime: false,
+      publishDate: '2024-01-01',
+      event: {},
+      isRequestPending: false,
+      orgEntitled: false,
+      userEntitled: false,
+      canRequestAccess: false,
+      disEntitledReasons: ['fakeReason']
+    };
+    addTemplate.mockReturnValue(template);
+    const response = await action.main({
+      IMS_URL: process.env.IMS_URL,
+      IMS_CLIENT_ID,
+      IMS_CLIENT_SECRET,
+      IMS_AUTH_CODE,
+      IMS_SCOPES,
+      TEMPLATE_REGISTRY_ORG: process.env.TEMPLATE_REGISTRY_ORG,
+      TEMPLATE_REGISTRY_REPOSITORY: process.env.TEMPLATE_REGISTRY_REPOSITORY,
+      ACCESS_TOKEN_GITHUB: process.env.ACCESS_TOKEN_GITHUB,
+      TEMPLATE_REGISTRY_API_URL: process.env.TEMPLATE_REGISTRY_API_URL,
+      __ow_method: HTTP_METHOD,
+      name: DEVELOPER_CONSOLE_TEMPLATE_NAME,
+      links: {
+        consoleProject: DEVELOPER_CONSOLE_PROJECT
+      },
+      description: 'Developer Console template',
+      latestVersion: '1.0.0',
+      createdBy: 'Capernicus',
+      author: 'Capernicus',
+      adobeRecommended: true,
+      status: 'Approved',
+      codeSamples: [
+        {
+          language: 'node',
+          link: 'https://developer-stage.adobe.com/sample.zip'
+        }
+      ],
+      requestAccessAppId: 'requestAccessAppId',
+      updatedBy: 'Capernicus',
+      keywords: ['Developer Console'],
+      categories: ['Templates'],
+      extensions: [{ extensionPointId: 'mockExtension' }],
+      credentials: [{ type: 'serviceAccount', flowType: 'oauth2' }],
+      apis: [{ credentialType: 'serviceAccount', flowType: 'oauth2', code: 'AdobeIO' }],
+      runtime: false,
+      publishDate: '2024-01-01',
+      event: {},
+      isRequestPending: false,
+      orgEntitled: false,
+      userEntitled: false,
+      canRequestAccess: false,
+      disEntitledReasons: ['fakeReason'],
+      ...fakeParams
+    });
+    expect(response).toEqual({
+      statusCode: 200,
+      body: {
+        ...template,
+        _links: {
+          self: {
+            href: `${process.env.TEMPLATE_REGISTRY_API_URL}/templates/${templateName}`
+          }
+        }
+      }
+    });
+    expect(mockLoggerInstance.info).toHaveBeenCalledWith('Calling "POST templates"');
+    expect(validateAccessToken).toHaveBeenCalledWith(IMS_ACCESS_TOKEN, process.env.IMS_URL, IMS_CLIENT_ID);
+    expect(findTemplateByName).toHaveBeenCalledWith({}, DEVELOPER_CONSOLE_TEMPLATE_NAME);
+    expect(addTemplate).toHaveBeenCalledWith({ MONGODB_NAME: undefined, MONGODB_URI: undefined }, {
+      name: DEVELOPER_CONSOLE_TEMPLATE_NAME,
+      links: {
+        consoleProject: DEVELOPER_CONSOLE_PROJECT
+      },
+      description: 'Developer Console template',
+      latestVersion: '1.0.0',
+      createdBy: 'Capernicus',
+      author: 'Capernicus',
+      adobeRecommended: true,
+      status: 'Approved',
+      codeSamples: [
+        {
+          language: 'node',
+          link: 'https://developer-stage.adobe.com/sample.zip'
+        }
+      ],
+      requestAccessAppId: 'requestAccessAppId',
+      updatedBy: 'Capernicus',
+      keywords: ['Developer Console'],
+      categories: ['Templates'],
+      extensions: [{ extensionPointId: 'mockExtension' }],
+      credentials: [{ type: 'serviceAccount', flowType: 'oauth2' }],
+      apis: [{ credentialType: 'serviceAccount', flowType: 'oauth2', code: 'AdobeIO' }],
+      runtime: false,
+      publishDate: '2024-01-01',
+      event: {},
+      isRequestPending: false,
+      orgEntitled: false,
+      userEntitled: false,
+      canRequestAccess: false,
+      disEntitledReasons: ['fakeReason']
+    });
+    // TODO: Uncomment the following after integrating with App Builder templates again
+    // expect(createReviewIssue).toHaveBeenCalledWith(TEMPLATE_NAME, TEMPLATE_GITHUB_REPO, process.env.ACCESS_TOKEN_GITHUB, process.env.TEMPLATE_REGISTRY_ORG, process.env.TEMPLATE_REGISTRY_REPOSITORY);
+    expect(mockLoggerInstance.info).toHaveBeenCalledWith('"POST templates" executed successfully');
+  });
+
+  test('Adding new developer console template with more additional fields, no credentials, should return 200', async () => {
+    findTemplateByName.mockReturnValue(null);
+    fetchUrl.mockReturnValue('');
+    const templateName = '@adobe/developer-console-template';
+    const template = {
+      id: '56bf8211-d92d-44ef-b98b-6ee89812e1d7',
+      name: templateName,
+      description: 'Developer Console template',
+      latestVersion: '1.0.0',
+      createdBy: 'Capernicus',
+      links: {
+        consoleProject: DEVELOPER_CONSOLE_PROJECT
+      },
+      author: 'Capernicus',
+      adobeRecommended: true,
+      status: 'Approved',
+      codeSamples: [
+        {
+          language: 'node',
+          link: 'https://developer-stage.adobe.com/sample.zip'
+        }
+      ],
+      requestAccessAppId: 'requestAccessAppId',
+      updatedBy: 'Capernicus',
+      keywords: ['Developer Console'],
+      categories: ['Templates'],
+      extensions: [{ extensionPointId: 'mockExtension' }],
+      apis: [{ credentialType: 'serviceAccount', flowType: 'oauth2', code: 'AdobeIO' }],
+      runtime: false,
+      publishDate: '2024-01-01',
+      event: {},
+      isRequestPending: false,
+      orgEntitled: false,
+      userEntitled: false,
+      canRequestAccess: false,
+      disEntitledReasons: ['fakeReason']
+    };
+    addTemplate.mockReturnValue(template);
+    const response = await action.main({
+      IMS_URL: process.env.IMS_URL,
+      IMS_CLIENT_ID,
+      IMS_CLIENT_SECRET,
+      IMS_AUTH_CODE,
+      IMS_SCOPES,
+      TEMPLATE_REGISTRY_ORG: process.env.TEMPLATE_REGISTRY_ORG,
+      TEMPLATE_REGISTRY_REPOSITORY: process.env.TEMPLATE_REGISTRY_REPOSITORY,
+      ACCESS_TOKEN_GITHUB: process.env.ACCESS_TOKEN_GITHUB,
+      TEMPLATE_REGISTRY_API_URL: process.env.TEMPLATE_REGISTRY_API_URL,
+      __ow_method: HTTP_METHOD,
+      name: DEVELOPER_CONSOLE_TEMPLATE_NAME,
+      links: {
+        consoleProject: DEVELOPER_CONSOLE_PROJECT
+      },
+      description: 'Developer Console template',
+      latestVersion: '1.0.0',
+      createdBy: 'Capernicus',
+      author: 'Capernicus',
+      adobeRecommended: true,
+      status: 'Approved',
+      codeSamples: [
+        {
+          language: 'node',
+          link: 'https://developer-stage.adobe.com/sample.zip'
+        }
+      ],
+      requestAccessAppId: 'requestAccessAppId',
+      updatedBy: 'Capernicus',
+      keywords: ['Developer Console'],
+      categories: ['Templates'],
+      extensions: [{ extensionPointId: 'mockExtension' }],
+      apis: [{ credentialType: 'serviceAccount', flowType: 'oauth2', code: 'AdobeIO' }],
+      runtime: false,
+      publishDate: '2024-01-01',
+      event: {},
+      isRequestPending: false,
+      orgEntitled: false,
+      userEntitled: false,
+      canRequestAccess: false,
+      disEntitledReasons: ['fakeReason'],
+      ...fakeParams
+    });
+    expect(response).toEqual({
+      statusCode: 200,
+      body: {
+        ...template,
+        _links: {
+          self: {
+            href: `${process.env.TEMPLATE_REGISTRY_API_URL}/templates/${templateName}`
+          }
+        }
+      }
+    });
+    expect(mockLoggerInstance.info).toHaveBeenCalledWith('Calling "POST templates"');
+    expect(validateAccessToken).toHaveBeenCalledWith(IMS_ACCESS_TOKEN, process.env.IMS_URL, IMS_CLIENT_ID);
+    expect(findTemplateByName).toHaveBeenCalledWith({}, DEVELOPER_CONSOLE_TEMPLATE_NAME);
+    expect(addTemplate).toHaveBeenCalledWith({ MONGODB_NAME: undefined, MONGODB_URI: undefined }, {
+      name: DEVELOPER_CONSOLE_TEMPLATE_NAME,
+      links: {
+        consoleProject: DEVELOPER_CONSOLE_PROJECT
+      },
+      description: 'Developer Console template',
+      latestVersion: '1.0.0',
+      createdBy: 'Capernicus',
+      author: 'Capernicus',
+      adobeRecommended: true,
+      status: 'Approved',
+      codeSamples: [
+        {
+          language: 'node',
+          link: 'https://developer-stage.adobe.com/sample.zip'
+        }
+      ],
+      requestAccessAppId: 'requestAccessAppId',
+      updatedBy: 'Capernicus',
+      keywords: ['Developer Console'],
+      categories: ['Templates'],
+      extensions: [{ extensionPointId: 'mockExtension' }],
+      apis: [{ credentialType: 'serviceAccount', flowType: 'oauth2', code: 'AdobeIO' }],
+      runtime: false,
+      publishDate: '2024-01-01',
+      event: {},
+      isRequestPending: false,
+      orgEntitled: false,
+      userEntitled: false,
+      canRequestAccess: false,
+      disEntitledReasons: ['fakeReason']
+    });
+    // TODO: Uncomment the following after integrating with App Builder templates again
+    // expect(createReviewIssue).toHaveBeenCalledWith(TEMPLATE_NAME, TEMPLATE_GITHUB_REPO, process.env.ACCESS_TOKEN_GITHUB, process.env.TEMPLATE_REGISTRY_ORG, process.env.TEMPLATE_REGISTRY_REPOSITORY);
+    expect(mockLoggerInstance.info).toHaveBeenCalledWith('"POST templates" executed successfully');
+  });
 });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
When the request body to POST /templates includes apis or credentials, we need to bypass the get install config step and just save the passed request body. 
The request body schema for POST /templates will need to be expanded to include the full template schema, except for id (This is set by Mongo). 
This PR addresses these issues.
<!--- Describe your changes in detail -->

## Related Issue
https://jira.corp.adobe.com/browse/ACNA-3007
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
