### PR TITLE
chore: remove unused uuid dep

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,8 +9,7 @@
     "axios": "^0.27.2",
     "lodash.orderby": "^4.6.0",
     "mongodb": "^6.5.0",
-    "openapi-enforcer": "^1.23.0",
-    "uuid": "^9.0.1"
+    "openapi-enforcer": "^1.23.0"
   },
   "devDependencies": {
     "@adobe/eslint-config-aio-lib-config": "^4.0.0",


### PR DESCRIPTION
Saw https://github.com/adobe/adp-template-registry-api/pull/61 but remembered we now rely on Mongo to generate IDs for templates, so remove unused `uuid`