### PR TITLE
tmp: disable stage smoke tests

### DIFF
--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -17,7 +17,7 @@ on:
         default: 'Stage'
   schedule:
     - cron: '*/5 * * * *' # Run prod every 5 minutes
-    - cron: '*/60 * * * *' # Run stage every hour
+    # - cron: '*/60 * * * *' # Run stage every hour
 
 jobs:
   smoke:


### PR DESCRIPTION
Seems to be something wrong with runtime stage. Will re-enable when it's fixed

https://adobeio.slack.com/archives/GQST7AQRK/p1733790964073009