### PR TITLE
refactor: replace axios and node-fetch with native fetch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,4 @@ logs
 # yalc
 .yalc
 yalc.lock
+.claude

--- a/actions/ims.js
+++ b/actions/ims.js
@@ -9,7 +9,6 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-const axios = require('axios').default;
 const { Ims, getTokenData } = require('@adobe/aio-lib-ims');
 const { getEnv } = require('./utils');
 
@@ -84,29 +83,25 @@ function isValidServiceToken (accessToken, requiredScopes = []) {
  * @private
  */
 async function requestImsResource (url, accessToken, headers = {}, params = {}) {
-  return new Promise((resolve, reject) => {
-    axios({
-      method: 'get',
-      url,
+  const urlObj = new URL(url);
+  for (const [k, v] of Object.entries(params)) {
+    urlObj.searchParams.set(k, v);
+  }
+  let response;
+  try {
+    response = await fetch(urlObj.toString(), {
       headers: {
         Authorization: `Bearer ${accessToken}`,
         ...headers
-      },
-      params
-    })
-      .then(response => {
-        if (response.status === 200) {
-          resolve(response.data);
-        } else {
-          const error = `Error fetching "${url}". Response code is ${response.status}`;
-          reject(new Error(error));
-        }
-      })
-      .catch(e => {
-        const error = `Error fetching "${url}". ${e.toString()}`;
-        reject(new Error(error));
-      });
-  });
+      }
+    });
+  } catch (e) {
+    throw new Error(`Error fetching "${url}". ${e.toString()}`);
+  }
+  if (response.status === 200) {
+    return response.json();
+  }
+  throw new Error(`Error fetching "${url}". Response code is ${response.status}`);
 }
 
 /**

--- a/actions/templateRegistry.js
+++ b/actions/templateRegistry.js
@@ -9,7 +9,6 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-const axios = require('axios').default;
 const { Octokit } = require('@octokit/rest');
 
 const collectionName = 'templates';
@@ -197,26 +196,20 @@ async function getTemplates (dbParams) {
  * @returns {Promise} response data
  */
 async function fetchUrl (url, headers = {}, params = {}) {
-  return new Promise((resolve, reject) => {
-    axios({
-      method: 'get',
-      url,
-      headers,
-      params
-    })
-      .then(response => {
-        if (response.status === 200) {
-          resolve(response.data);
-        } else {
-          const error = `Error fetching "${url}". Response code is ${response.status}`;
-          reject(new Error(error));
-        }
-      })
-      .catch(e => {
-        const error = `Error fetching "${url}". ${e.toString()}`;
-        reject(new Error(error));
-      });
-  });
+  const urlObj = new URL(url);
+  for (const [k, v] of Object.entries(params)) {
+    urlObj.searchParams.set(k, v);
+  }
+  let response;
+  try {
+    response = await fetch(urlObj.toString(), { headers });
+  } catch (e) {
+    throw new Error(`Error fetching "${url}". ${e.toString()}`);
+  }
+  if (response.status === 200) {
+    return response.json();
+  }
+  throw new Error(`Error fetching "${url}". Response code is ${response.status}`);
 }
 
 module.exports = {

--- a/e2e/.env.example
+++ b/e2e/.env.example
@@ -1,0 +1,10 @@
+ # See https://github.com/adobe/aio-lib-templates for the value
+ TEMPLATE_REGISTRY_API_URL=
+ IMS_CLIENT_ID=
+ IMS_CLIENT_SECRET=
+ IMS_AUTH_CODE=
+ IMS_SCOPE=
+ # usually https://ims-na1.adobelogin.com, but can be different for other regions
+ IMS_URL=
+ # if set, we don't need to get an access token using the IMS_* values, and can just use this token directly
+ ACCESS_TOKEN=

--- a/e2e/.env.example
+++ b/e2e/.env.example
@@ -3,7 +3,7 @@
  IMS_CLIENT_ID=
  IMS_CLIENT_SECRET=
  IMS_AUTH_CODE=
- IMS_SCOPE=
+ IMS_SCOPES=
  # usually https://ims-na1.adobelogin.com, but can be different for other regions
  IMS_URL=
  # if set, we don't need to get an access token using the IMS_* values, and can just use this token directly

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -2,23 +2,33 @@
 
 ## Requirements
 
-To run the e2e test you'll need these env variables set:
-  0. Create `.env` in `e2e` directory and SET:
-  1. `TEMPLATE_REGISTRY_API_URL`
-  2. `AUTH_TOKEN`
-  3. `IMS_CLIENT_ID`=`
-  4. `IMS_CLIENT_SECRET`=`
-  5. `IMS_AUTH_CODE`=`
-  6. `IMS_SCOPES`=`
-  7. `IMS_URL`=`
-  8. `ACCESS_TOKEN`
+1. Copy `.env.example` to `.env` in the `e2e` directory
+2. Set the required variables in `.env` (see below)
+
+### Environment variables
+
+| Variable | Required | Description |
+|---|---|---|
+| `TEMPLATE_REGISTRY_API_URL` | Yes | Base URL of the Template Registry API |
+| `IMS_URL` | Yes | IMS host URL (e.g. `https://ims-na1.adobelogin.com`) |
+| `ACCESS_TOKEN` | No* | Pre-generated IMS access token. If set, the IMS auth variables below are not needed. |
+| `IMS_AUTH_CODE` | No* | IMS auth code — required when `ACCESS_TOKEN` is not set |
+| `IMS_CLIENT_ID` | No* | IMS client ID — required when `ACCESS_TOKEN` is not set |
+| `IMS_CLIENT_SECRET` | No* | IMS client secret — required when `ACCESS_TOKEN` is not set |
+| `IMS_SCOPES` | No* | Space-separated IMS scopes — required when `ACCESS_TOKEN` is not set |
+
+\* Either `ACCESS_TOKEN` **or** all four IMS auth variables must be provided. The test suite will print a clear error for each missing variable and abort before any tests run.
 
 ## Run
 
-`npm run e2e`
+```
+npm run e2e
+```
 
 ## Test overview
 
 The tests cover:
 
-1. Template Registry API CRUD Operations
+- Template Registry API CRUD Operations (create, read, update, delete)
+- Console template lifecycle
+- Concurrent template operations and basic performance benchmarking

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -11,13 +11,13 @@
 |---|---|---|
 | `TEMPLATE_REGISTRY_API_URL` | Yes | Base URL of the Template Registry API |
 | `IMS_URL` | Yes | IMS host URL (e.g. `https://ims-na1.adobelogin.com`) |
+| `IMS_CLIENT_ID` | Yes | IMS client ID — always required (used to validate the access token) |
 | `ACCESS_TOKEN` | No* | Pre-generated IMS access token. If set, the IMS auth variables below are not needed. |
 | `IMS_AUTH_CODE` | No* | IMS auth code — required when `ACCESS_TOKEN` is not set |
-| `IMS_CLIENT_ID` | No* | IMS client ID — required when `ACCESS_TOKEN` is not set |
 | `IMS_CLIENT_SECRET` | No* | IMS client secret — required when `ACCESS_TOKEN` is not set |
 | `IMS_SCOPES` | No* | Space-separated IMS scopes — required when `ACCESS_TOKEN` is not set |
 
-\* Either `ACCESS_TOKEN` **or** all four IMS auth variables must be provided. The test suite will print a clear error for each missing variable and abort before any tests run.
+\* Either `ACCESS_TOKEN` **or** all three IMS auth variables (`IMS_AUTH_CODE`, `IMS_CLIENT_SECRET`, `IMS_SCOPES`) must be provided. The test suite will print a clear error for each missing variable and abort before any tests run.
 
 ## Run
 

--- a/e2e/e2e.js
+++ b/e2e/e2e.js
@@ -13,6 +13,22 @@ const {
   ACCESS_TOKEN
 } = process.env;
 
+const alwaysRequired = { IMS_URL, TEMPLATE_REGISTRY_API_URL };
+const tokenRequired = { IMS_AUTH_CODE, IMS_CLIENT_ID, IMS_CLIENT_SECRET, IMS_SCOPES };
+
+const missing = Object.entries(alwaysRequired)
+  .filter(([, v]) => !v)
+  .map(([k]) => k);
+
+if (!ACCESS_TOKEN) {
+  missing.push(...Object.entries(tokenRequired).filter(([, v]) => !v).map(([k]) => k));
+}
+
+if (missing.length > 0) {
+  missing.forEach(k => console.error(`Missing required environment variable: ${k}`));
+  throw new Error(`E2E setup failed: missing environment variables: ${missing.join(', ')}`);
+}
+
 /**
  * @param {string} accessToken - token to access API
  * @param {object} templateData contains name and links

--- a/e2e/e2e.js
+++ b/e2e/e2e.js
@@ -13,8 +13,8 @@ const {
   ACCESS_TOKEN
 } = process.env;
 
-const alwaysRequired = { IMS_URL, TEMPLATE_REGISTRY_API_URL };
-const tokenRequired = { IMS_AUTH_CODE, IMS_CLIENT_ID, IMS_CLIENT_SECRET, IMS_SCOPES };
+const alwaysRequired = { IMS_URL, IMS_CLIENT_ID, TEMPLATE_REGISTRY_API_URL };
+const tokenRequired = { IMS_AUTH_CODE, IMS_CLIENT_SECRET, IMS_SCOPES };
 
 const missing = Object.entries(alwaysRequired)
   .filter(([, v]) => !v)

--- a/e2e/e2e.js
+++ b/e2e/e2e.js
@@ -1,7 +1,6 @@
 require('dotenv').config({ path: require('path').resolve(__dirname, '.env') });
 jest.setTimeout(60000);
 
-const fetch = require('node-fetch');
 const { validateAccessToken, generateAccessToken } = require('../actions/ims');
 
 const {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,6 @@
     "@adobe/aio-metrics-client": "^0.4.0",
     "@adobe/aio-sdk": "^5.0.1",
     "@octokit/rest": "^20.0.2",
-    "axios": "^0.27.2",
     "lodash.orderby": "^4.6.0",
     "mongodb": "^6.5.0",
     "openapi-enforcer": "^1.23.0"
@@ -28,7 +27,6 @@
     "jest": "^29.7.0",
     "jest-junit": "^16.0.0",
     "nock": "^13.5.4",
-    "node-fetch": "^2.6.7",
     "np": "^10.0.5"
   },
   "scripts": {

--- a/test/ims.test.js
+++ b/test/ims.test.js
@@ -9,7 +9,6 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-const nock = require('nock');
 const { Ims, getTokenData } = require('@adobe/aio-lib-ims');
 const { validateAccessToken, isAdmin, generateAccessToken, isValidServiceToken } = require('../actions/ims');
 
@@ -29,25 +28,14 @@ beforeEach(() => {
 
 describe('Verify communication with IMS', () => {
   test('Verify checking that provided IMS access token is valid', async () => {
-    nock(process.env.IMS_URL)
-      .get(`/ims/validate_token/v1?client_id=${process.env.IMS_CLIENT_ID}&type=access_token`)
-      .times(1)
-      .reply(200, {
-        valid: true
-      });
+    jest.spyOn(global, 'fetch').mockResolvedValue({ status: 200, json: async () => ({ valid: true }) });
 
     await expect(validateAccessToken('<access-token>', process.env.IMS_URL, process.env.IMS_CLIENT_ID))
       .resolves.toBeUndefined();
   });
 
   test('Verify that exception is thrown for non-valid IMS access token', async () => {
-    nock(process.env.IMS_URL)
-      .get(`/ims/validate_token/v1?client_id=${process.env.IMS_CLIENT_ID}&type=access_token`)
-      .times(1)
-      .reply(200, {
-        valid: false,
-        reason: 'bad_signature'
-      });
+    jest.spyOn(global, 'fetch').mockResolvedValue({ status: 200, json: async () => ({ valid: false, reason: 'bad_signature' }) });
 
     await expect(validateAccessToken('<access-token>', process.env.IMS_URL, process.env.IMS_CLIENT_ID))
       .rejects.toThrow('Provided IMS access token is invalid. Reason: bad_signature');
@@ -57,21 +45,13 @@ describe('Verify communication with IMS', () => {
     const adminImsOrganizations = [
       'adminOrg@AdobeOrg'
     ];
-    nock(process.env.IMS_URL)
-      .get('/ims/organizations/v6')
-      .times(1)
-      .reply(200, [
-        {
-          orgName: 'Org1',
-          orgRef: { ident: 'adminOrg', authSrc: 'AdobeOrg' },
-          orgType: 'Enterprise'
-        },
-        {
-          orgName: 'Org2',
-          orgRef: { ident: 'non-adminOrg', authSrc: 'AdobeOrg' },
-          orgType: 'Enterprise'
-        }
-      ]);
+    jest.spyOn(global, 'fetch').mockResolvedValue({
+      status: 200,
+      json: async () => [
+        { orgName: 'Org1', orgRef: { ident: 'adminOrg', authSrc: 'AdobeOrg' }, orgType: 'Enterprise' },
+        { orgName: 'Org2', orgRef: { ident: 'non-adminOrg', authSrc: 'AdobeOrg' }, orgType: 'Enterprise' }
+      ]
+    });
 
     await expect(isAdmin('<access-token>', process.env.IMS_URL, adminImsOrganizations))
       .resolves.toBe(true);
@@ -81,41 +61,34 @@ describe('Verify communication with IMS', () => {
     const adminImsOrganizations = [
       'adminOrg@AdobeOrg'
     ];
-    nock(process.env.IMS_URL)
-      .get('/ims/organizations/v6')
-      .times(1)
-      .reply(200, [
-        {
-          orgName: 'Org1',
-          orgRef: { ident: 'non-adminOrg1', authSrc: 'AdobeOrg' },
-          orgType: 'Enterprise'
-        },
-        {
-          orgName: 'Org2',
-          orgRef: { ident: 'non-adminOrg2', authSrc: 'AdobeOrg' },
-          orgType: 'Enterprise'
-        }
-      ]);
+    jest.spyOn(global, 'fetch').mockResolvedValue({
+      status: 200,
+      json: async () => [
+        { orgName: 'Org1', orgRef: { ident: 'non-adminOrg1', authSrc: 'AdobeOrg' }, orgType: 'Enterprise' },
+        { orgName: 'Org2', orgRef: { ident: 'non-adminOrg2', authSrc: 'AdobeOrg' }, orgType: 'Enterprise' }
+      ]
+    });
 
     await expect(isAdmin('<access-token>', process.env.IMS_URL, adminImsOrganizations))
       .resolves.toBe(false);
   });
 
   test('Verify that exception is thrown for non-successful IMS communication', async () => {
-    nock(process.env.IMS_URL)
-      .get('/ims/organizations/v6')
-      .times(1)
-      .reply(400);
+    jest.spyOn(global, 'fetch').mockResolvedValue({ status: 400, json: async () => ({}) });
 
     await expect(isAdmin('<access-token>', process.env.IMS_URL, []))
-      .rejects.toThrow(`Error fetching "${process.env.IMS_URL}/ims/organizations/v6". AxiosError: Request failed with status code 400`);
+      .rejects.toThrow(`Error fetching "${process.env.IMS_URL}/ims/organizations/v6". Response code is 400`);
+  });
+
+  test('Verify that exception is thrown for network error during IMS communication', async () => {
+    jest.spyOn(global, 'fetch').mockRejectedValue(new Error('network failure'));
+
+    await expect(isAdmin('<access-token>', process.env.IMS_URL, []))
+      .rejects.toThrow(`Error fetching "${process.env.IMS_URL}/ims/organizations/v6". Error: network failure`);
   });
 
   test('Verify that exception is thrown for non-successful IMS communication, non-error code', async () => {
-    nock(process.env.IMS_URL)
-      .get('/ims/organizations/v6')
-      .times(1)
-      .reply(201);
+    jest.spyOn(global, 'fetch').mockResolvedValue({ status: 201, json: async () => ({}) });
 
     await expect(isAdmin('<access-token>', process.env.IMS_URL, []))
       .rejects.toThrow(`Error fetching "${process.env.IMS_URL}/ims/organizations/v6". Response code is 201`);

--- a/test/smoke.test.js
+++ b/test/smoke.test.js
@@ -9,7 +9,6 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-const fetch = require('node-fetch');
 require('dotenv').config();
 const { Ims } = require('@adobe/aio-lib-ims');
 const testConsoleTemplate = require('./fixtures/smoke/template.console.json');

--- a/test/templateRegistry.test.js
+++ b/test/templateRegistry.test.js
@@ -10,7 +10,6 @@ governing permissions and limitations under the License.
 */
 
 const { MongoClient, ObjectId } = require('mongodb');
-const nock = require('nock');
 const {
   fetchUrl,
   createReviewIssue,
@@ -47,10 +46,9 @@ describe('Verify communication with Template Registry', () => {
   test('Returns an open "Template Review Request" issue', async () => {
     const templateName = '@adobe/app-builder-template';
     const issueUrl = `https://github.com/${process.env.TEMPLATE_REGISTRY_ORG}/${process.env.TEMPLATE_REGISTRY_REPOSITORY}/issues/2`;
-    nock('https://api.github.com')
-      .get(`/repos/${process.env.TEMPLATE_REGISTRY_ORG}/${process.env.TEMPLATE_REGISTRY_REPOSITORY}/issues?state=open&labels=add-template&sort=updated-desc`)
-      .times(1)
-      .reply(200, [
+    jest.spyOn(global, 'fetch').mockResolvedValue({
+      status: 200,
+      json: async () => [
         {
           html_url: `https://github.com/${process.env.TEMPLATE_REGISTRY_ORG}/${process.env.TEMPLATE_REGISTRY_REPOSITORY}/issues/1`,
           body: '### Link to GitHub repo\nhttps://github.com/company1/app-builder-template\n### npm package name\n@company1/app-builder-template'
@@ -59,7 +57,8 @@ describe('Verify communication with Template Registry', () => {
           html_url: issueUrl,
           body: `### Link to GitHub repo\nhttps://github.com/adobe/app-builder-template\n### npm package name\n${templateName}`
         }
-      ]);
+      ]
+    });
 
     await expect(getReviewIssueByTemplateName(templateName, process.env.TEMPLATE_REGISTRY_ORG, process.env.TEMPLATE_REGISTRY_REPOSITORY))
       .resolves.toBe(issueUrl);
@@ -311,15 +310,11 @@ describe('Template Registry Mongodb CRUD Actions', () => {
     expect(templatesResult).toEqual(null);
   });
 
-  test('axios fetchUrl should return the response body', async () => {
-    nock('https://jsonplaceholder.typicode.com')
-      .get('/posts/1')
-      .reply(200, {
-        userId: 1,
-        id: 1,
-        title: 'title',
-        body: 'body'
-      });
+  test('fetchUrl should return the response body', async () => {
+    jest.spyOn(global, 'fetch').mockResolvedValue({
+      status: 200,
+      json: async () => ({ userId: 1, id: 1, title: 'title', body: 'body' })
+    });
 
     const url = 'https://jsonplaceholder.typicode.com/posts/1';
     const response = await fetchUrl(url);
@@ -331,32 +326,32 @@ describe('Template Registry Mongodb CRUD Actions', () => {
     });
   });
 
-  test('axios fetchUrl returns non-200 status code', async () => {
-    nock('https://jsonplaceholder.typicode.com')
-      .get('/posts/1')
-      .reply(201, {
-        userId: 1,
-        id: 1,
-        title: 'title',
-        body: 'body'
-      });
+  test('fetchUrl returns non-200 status code', async () => {
+    jest.spyOn(global, 'fetch').mockResolvedValue({ status: 201, json: async () => ({}) });
 
     const url = 'https://jsonplaceholder.typicode.com/posts/1';
     await expect(fetchUrl(url)).rejects.toThrow('Error fetching "https://jsonplaceholder.typicode.com/posts/1". Response code is 201');
   });
 
-  test('axios fetchUrl returns 400 status code', async () => {
-    nock('https://jsonplaceholder.typicode.com')
-      .get('/posts/1')
-      .reply(400, {
-        userId: 1,
-        id: 1,
-        title: 'title',
-        body: 'body'
-      });
+  test('fetchUrl returns 400 status code', async () => {
+    jest.spyOn(global, 'fetch').mockResolvedValue({ status: 400, json: async () => ({}) });
 
     const url = 'https://jsonplaceholder.typicode.com/posts/1';
-    await expect(fetchUrl(url)).rejects.toThrow('Error fetching "https://jsonplaceholder.typicode.com/posts/1". AxiosError: Request failed with status code 400');
+    await expect(fetchUrl(url)).rejects.toThrow('Error fetching "https://jsonplaceholder.typicode.com/posts/1". Response code is 400');
+  });
+
+  test('fetchUrl throws on network error', async () => {
+    jest.spyOn(global, 'fetch').mockRejectedValue(new Error('network failure'));
+
+    const url = 'https://jsonplaceholder.typicode.com/posts/1';
+    await expect(fetchUrl(url)).rejects.toThrow('Error fetching "https://jsonplaceholder.typicode.com/posts/1". Error: network failure');
+  });
+
+  test('fetchUrl should append query params to the URL', async () => {
+    const spy = jest.spyOn(global, 'fetch').mockResolvedValue({ status: 200, json: async () => ([]) });
+
+    await fetchUrl('https://api.example.com/items', {}, { page: '1', limit: '10' });
+    expect(spy).toHaveBeenCalledWith('https://api.example.com/items?page=1&limit=10', expect.any(Object));
   });
 
   test('create issue for a template', async () => {


### PR DESCRIPTION
## Summary

- Remove `axios` (prod dependency) and `node-fetch` (dev dependency) — both are redundant since the project requires Node.js 22, which ships `fetch` globally
- Rewrite `requestImsResource` (ims.js) and `fetchUrl` (templateRegistry.js) using native `fetch` with `URLSearchParams` for query params
- Replace `nock`-based HTTP mocks in `ims.test.js` and `templateRegistry.test.js` with `jest.spyOn(global, 'fetch')` — nock intercepts the `http` module but not undici-based native fetch
- Add tests for network errors (fetch throws) and query-param URL building to maintain 100% coverage
- `nock` is kept for `templates.list.test.js` which mocks `openapi-enforcer` library calls (still uses the http module)

## Test plan

- [x] `npm run lint:check` — no lint errors
- [x] `npm run unit-tests` — 197 tests pass, 100% coverage across all thresholds
- [ ] `npm run e2e` — run against a live environment to confirm end-to-end behaviour (PENDING) - right now on merge to main, it will auto-deploy to Stage for testing

🤖 Generated with [Claude Code](https://claude.com/claude-code)